### PR TITLE
update snow overburden compaction parameter

### DIFF
--- a/src/biogeophys/SnowHydrologyMod.F90
+++ b/src/biogeophys/SnowHydrologyMod.F90
@@ -1905,7 +1905,7 @@ contains
     real(r8) :: f1, f2                          ! overburden compaction modifiers to viscosity
     real(r8) :: eta                             ! Viscosity
 
-    real(r8), parameter :: ceta = 450._r8       ! overburden compaction constant [kg/m3]
+    real(r8), parameter :: ceta = 358._r8       ! overburden compaction constant [kg/m3]
     real(r8), parameter :: aeta = 0.1_r8        ! overburden compaction constant [1/K]
     real(r8), parameter :: beta = 0.023_r8      ! overburden compaction constant [m3/kg]
     real(r8), parameter :: eta0 = 7.62237e6_r8  ! The Viscosity Coefficient Eta0 [kg-s/m2]


### PR DESCRIPTION
Snow viscosity for dry compaction was changed in 2016 and is described in more detail by (Van Kampenhout et al., 2017). Basically we adopted an expression from Crocus (Vionnet et al, 2012) and changed one parameter (c_eta) to better fit firn core observations. The original value of the c_eta parameter in Vionnet2012 is 250 kg/m3. In our study we tested different values (like 450) before arriving at the final value of 358 kg/m3. In this commit we change the value of c_eta from 450 to 358 kg/m3.